### PR TITLE
Change date format to ISO8601

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
       } else {
          for (int i=0; i<missionSamples; i++) {
             char buffer[64];
-            strftime(buffer, 64, "%x %X", localtime(&tt));
+            strftime(buffer, 64, "%F %X", localtime(&tt));
             cout << buffer << ": " << values[(i+posOldestValue)%maxMissionSamples] << endl;
             tt += sampleRate;
          }


### PR DESCRIPTION
This is just how we use this internally. Won't be offended if you hate the idea! We find the YYYY-MM-DD format makes it easier to parse the data.